### PR TITLE
MANTA-4680 buckets-mdapi could return more information about deleted objects

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -100,10 +100,10 @@ pub struct DeleteObjectResponse {
 
 impl DeleteObjectResponse {
     pub fn to_json(&self) -> Value {
-        // Similar to ObjectResponse, the serialization to JSON might fail. However, since
-        // DeleteObjectResponse is a subset of ObjectResponse, we assume that as long
-        // as ObjectResponse can be serialized, so DeleteObjectResponse. If this  is not
-        // enough of a guarantee, we can add test cases to make sure it is always the case.
+        // Similar to ObjectResponse, the serialization to JSON might fail if the
+        // implementation of Serialize decideds to fail. We have JSON roundtrip
+        // quickcheck testing to verify we can serialize and deserialize the same
+        // object safely and correctly.
         serde_json::to_value(self).expect("failed to serialize DeleteObjectResponse")
     }
 }
@@ -306,6 +306,19 @@ mod test {
         }
     }
 
+    impl Arbitrary for DeleteObjectResponse {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Self {
+                id: Uuid::new_v4(),
+                owner: Uuid::new_v4(),
+                bucket_id: Uuid::new_v4(),
+                name: random::string(g, 32),
+                content_length: i64::arbitrary(g),
+                shark_count: i32::arbitrary(g),
+            }
+        }
+    }
+
     quickcheck! {
         fn prop_get_object_payload_roundtrip(msg: GetObjectPayload) -> bool {
             match serde_json::to_string(&msg) {
@@ -335,6 +348,21 @@ mod test {
                 },
                 Err(_) => false
             }
+        }
+    }
+    quickcheck! {
+        fn prop_delete_object_response_roundtrip(dobjr: DeleteObjectResponse) -> bool {
+              match serde_json::to_string(&dobjr) {
+                 Ok(dobjr_str) => {
+                   let decode_result: Result<DeleteObjectResponse, _> =
+                         serde_json::from_str(&dobjr_str);
+                        match decode_result {
+                        Ok(decoded_dobjr) => decoded_dobjr == dobjr,
+                            Err(_) => false
+                       }
+                   },
+                  Err(_) => false
+             }
         }
     }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -89,6 +89,26 @@ impl<'a> FromSql<'a> for StorageNodeIdentifier {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DeleteObjectResponse {
+    pub id: Uuid,
+    pub owner: Uuid,
+    pub bucket_id: Uuid,
+    pub name: String,
+    pub content_length: i64,
+    pub shark_count: i32,
+}
+
+impl DeleteObjectResponse {
+    pub fn to_json(&self) -> Value {
+        // Similar to ObjectResponse, the serialization to JSON might fail. However, since
+        // DeleteObjectResponse is a subset of ObjectResponse, we assume that as long
+        // as ObjectResponse can be serialized, so DeleteObjectResponse. If this  is not
+        // enough of a guarantee, we can add test cases to make sure it is always the case.
+        serde_json::to_value(self).expect("failed to serialize DeleteObjectResponse")
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ObjectResponse {
     pub id: Uuid,
     pub owner: Uuid,

--- a/src/object/delete.rs
+++ b/src/object/delete.rs
@@ -87,7 +87,7 @@ fn do_delete(
     })
     .and_then(|deleted_objects| {
         let mut objs = vec![];
-        for row in deleted_objects.into_iter() {
+        for row in deleted_objects {
             /*
              * As of now, there is no constraint in the database to guarantee that
              * 'content_length' is not null, as a result of that we need to be cautious

--- a/tests/rpc_handlers.rs
+++ b/tests/rpc_handlers.rs
@@ -395,10 +395,14 @@ fn verify_rpc_handlers() {
     let delete_object_response = delete_object_result.unwrap();
     assert_eq!(delete_object_response.len(), 1);
 
-    let delete_object_response_result: Result<u64, _> =
+    let delete_object_response_result: Result<Vec<object::DeleteObjectResponse>, _> =
         serde_json::from_value(delete_object_response[0].data.d[0].clone());
     assert!(delete_object_response_result.is_ok());
-    assert_eq!(delete_object_response_result.unwrap(), 1);
+    let delete_object_response = delete_object_response_result.unwrap();
+    assert_eq!(delete_object_response.len(), 1);
+    assert_eq!(&delete_object_response[0].owner, &owner_id);
+    assert_eq!(&delete_object_response[0].bucket_id, &bucket_id);
+    assert_eq!(&delete_object_response[0].name, &object);
 
     // Read object again and verify it is not found
     get_object_result = util::handle_msg(&get_object_fast_msg, &pool, &log);


### PR DESCRIPTION
Instead of returning the number of deleted objects, with this change `mdapi` returns a JSON array containing information about deleted objects. The main motive behind this change, is to aggregate information about deleted objects in the consumer of `mdapi`, `buckets-api` in this case and make it available for reporting or any other monitoring purpose.

See the JIRA tickets for more detail.