### PR TITLE
MANTA-4834 schema-manager must use the default postgres user and database initially

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,6 +2414,7 @@ name = "utils"
 version = "0.1.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cueball 0.2.1 (git+https://github.com/joyent/rust-cueball?tag=v0.2.1)",
  "cueball-manatee-primary-resolver 0.1.0 (git+https://github.com/joyent/rust-cueball-manatee-primary-resolver?tag=v0.1.0)",
  "cueball-postgres-connection 0.1.1 (git+https://github.com/joyent/rust-cueball-postgres-connection?tag=v0.1.1)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 Joyent, Inc
+# Copyright 2019 Joyent, Inc.
 #
 
 NAME = manta-boray

--- a/schema-manager/src/main.rs
+++ b/schema-manager/src/main.rs
@@ -176,10 +176,7 @@ fn run(log: &Logger) -> Result<(), Box<dyn std::error::Error>> {
         decoherence_interval: None,
     };
 
-    // Create two resolvers. One for the admin connection pool used to create
-    // the application role and database and another to create the schemas
-    // within the application database.
-    let resolver1 = ManateePrimaryResolver::new(
+    let resolver = ManateePrimaryResolver::new(
         boray_config.zookeeper.connection_string.clone(),
         boray_config.zookeeper.path.clone(),
         Some(log.new(o!(
@@ -187,7 +184,7 @@ fn run(log: &Logger) -> Result<(), Box<dyn std::error::Error>> {
         ))),
     );
 
-    let pool = ConnectionPool::new(pool_opts, resolver1, connection_creator);
+    let pool = ConnectionPool::new(pool_opts, resolver, connection_creator);
 
     let mut conn = pool
         .claim()

--- a/schema-manager/src/main.rs
+++ b/schema-manager/src/main.rs
@@ -61,15 +61,24 @@ fn init_sapi_client(sapi_address: &str, log: &Logger) -> Result<SAPI, Error> {
 // associated schemas on the shards
 fn parse_vnodes(
     conn: &mut PostgresConnection,
+    database_config: &config::ConfigDatabase,
+    zk_config: &config::ConfigZookeeper,
     log: &Logger,
     msg: &FastMessage,
 ) -> Result<(), Error> {
     let v: Vec<Value> = msg.data.d.as_array().unwrap().to_vec();
     for vnode in v {
         for v in vnode.as_array().unwrap() {
+            let resolver = ManateePrimaryResolver::new(
+                zk_config.connection_string.clone(),
+                zk_config.path.clone(),
+                Some(log.new(o!(
+                    "component" => "ManateePrimaryResolver"
+                ))),
+            );
             let vn = v.as_str().unwrap();
-            info!(log, "processing vnode: {:#?}", vn);
-            schema::create_bucket_schemas(conn, TEMPLATE_DIR, vn, log)?;
+            info!(log, "processing vnode: {}", vn);
+            schema::create_bucket_schemas(conn, database_config, resolver, TEMPLATE_DIR, vn, log)?;
         }
     }
     Ok(())
@@ -93,12 +102,14 @@ fn parse_opts<'a>(app: String) -> ArgMatches<'a> {
 // Callback function handed in to the fast::recieve call.
 fn vnode_response_handler(
     conn: &mut PostgresConnection,
+    database_config: &config::ConfigDatabase,
+    zk_config: &config::ConfigZookeeper,
     log: &Logger,
     msg: &FastMessage,
 ) -> Result<(), Error> {
     match msg.data.m.name.as_str() {
         "getvnodes" => {
-            parse_vnodes(conn, log, msg)?;
+            parse_vnodes(conn, database_config, zk_config, log, msg)?;
         }
         _ => warn!(log, "Received unrecognized {} response", msg.data.m.name),
     }
@@ -134,8 +145,8 @@ fn run(log: &Logger) -> Result<(), Box<dyn std::error::Error>> {
     });
 
     let tls_config = utils::config::tls::tls_config(
-        boray_config.database.tls_mode,
-        boray_config.database.certificate,
+        boray_config.database.tls_mode.clone(),
+        boray_config.database.certificate.clone(),
     )
     .unwrap_or_else(|e| {
         crit!(log, "TLS configuration error"; "err" => %e);
@@ -144,19 +155,19 @@ fn run(log: &Logger) -> Result<(), Box<dyn std::error::Error>> {
 
     // Create a connection pool using the admin user
     let pg_config = PostgresConnectionConfig {
-        user: Some(boray_config.database.user),
+        user: Some(boray_config.database.admin_user.clone()),
         password: None,
         host: None,
         port: None,
-        database: Some(boray_config.database.database),
-        application_name: Some(boray_config.database.application_name),
+        database: Some("postgres".into()),
+        application_name: Some("schema-manager".into()),
         tls_config,
     };
 
     let connection_creator = PostgresConnection::connection_creator(pg_config);
 
     let pool_opts = ConnectionPoolOptions {
-        max_connections: Some(boray_config.cueball.max_connections),
+        max_connections: Some(1),
         claim_timeout: Some(10000),
         log: Some(log.new(o!(
             "component" => "CueballConnectionPool"
@@ -165,22 +176,34 @@ fn run(log: &Logger) -> Result<(), Box<dyn std::error::Error>> {
         decoherence_interval: None,
     };
 
-    let resolver = ManateePrimaryResolver::new(
-        boray_config.zookeeper.connection_string,
-        boray_config.zookeeper.path,
+    // Create two resolvers. One for the admin connection pool used to create
+    // the application role and database and another to create the schemas
+    // within the application database.
+    let resolver1 = ManateePrimaryResolver::new(
+        boray_config.zookeeper.connection_string.clone(),
+        boray_config.zookeeper.path.clone(),
         Some(log.new(o!(
             "component" => "ManateePrimaryResolver"
         ))),
     );
 
-    let pool = ConnectionPool::new(pool_opts, resolver, connection_creator);
+    let pool = ConnectionPool::new(pool_opts, resolver1, connection_creator);
 
     let mut conn = pool
         .claim()
         .expect("failed to acquire postgres connection for vnode schema setup");
 
     let mut msg_id = FastMessageId::new();
-    let recv_cb = |msg: &FastMessage| vnode_response_handler(&mut conn, &log, msg);
+    let recv_cb = |msg: &FastMessage| {
+        vnode_response_handler(
+            &mut conn,
+            &boray_config.database,
+            &boray_config.zookeeper,
+            &log,
+            msg,
+        )
+    };
+
     let vnode_method = String::from("getvnodes");
 
     fast_client::send(vnode_method, json!([fast_arg]), &mut msg_id, &mut stream)

--- a/schema_templates/schema.in
+++ b/schema_templates/schema.in
@@ -1,5 +1,3 @@
-SET ROLE boray;
-
 CREATE EXTENSION IF NOT EXISTS hstore;
 
 CREATE SCHEMA IF NOT EXISTS manta_bucket_{{vnode}};

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 clap = "2.32"
+cueball = { git = "https://github.com/joyent/rust-cueball", tag = "v0.2.1" }
 cueball-manatee-primary-resolver = { git = "https://github.com/joyent/rust-cueball-manatee-primary-resolver", tag = "v0.1.0" }
 cueball-postgres-connection = { git = "https://github.com/joyent/rust-cueball-postgres-connection", tag = "v0.1.1" }
 num_cpus = { version = "1.8.0" }


### PR DESCRIPTION
Use one connection to the default postgres database using the default postgres
role to create the application role and database and a different connection to
the application database to create the schemas within that database. Also only
create a single connection in the connection pools since there will only ever be
a single connection needed from each one.

In testing the changes for #22 I made the mistake of only dropping the vnode schemas from my postgres database before reprovisioning my buckets-mdapi zone to a new image. This time I completely dropped the `boray` database as well as the `boray` role and then verified that everything was setup correctly after the execution of  the `schema-manager`.